### PR TITLE
use button elements instead of divs for piano keys

### DIFF
--- a/Lecture02/Exercise/templateExercise2/piano.html
+++ b/Lecture02/Exercise/templateExercise2/piano.html
@@ -10,25 +10,16 @@
 <body>
     <div class="container text-center my-5">
         <h1>Virtual Piano</h1>
-        <p>Press the following keys to play the notes:</p>
-        <ul class="list-inline">
-            <li class="list-inline-item"><strong>A</strong> - C</li>
-            <li class="list-inline-item"><strong>S</strong> - D</li>
-            <li class="list-inline-item"><strong>D</strong> - E</li>
-            <li class="list-inline-item"><strong>F</strong> - F</li>
-            <li class="list-inline-item"><strong>G</strong> - G</li>
-            <li class="list-inline-item"><strong>H</strong> - A</li>
-            <li class="list-inline-item"><strong>J</strong> - B</li>
-        </ul>
+        <p>Click or press keyboard keys <kbd>A</kbd> - <kbd>J</kbd> to play the notes.</p>
         <div id="piano" class="d-flex justify-content-center">
             <!-- Piano keys with IDs for JavaScript interaction -->
-            <div class="key" id="keyC">C</div>
-            <div class="key" id="keyD">D</div>
-            <div class="key" id="keyE">E</div>
-            <div class="key" id="keyF">F</div>
-            <div class="key" id="keyG">G</div>
-            <div class="key" id="keyA">A</div>
-            <div class="key" id="keyB">B</div>
+            <button class="key" id="keyC">C</button>
+            <button class="key" id="keyD">D</button>
+            <button class="key" id="keyE">E</button>
+            <button class="key" id="keyF">F</button>
+            <button class="key" id="keyG">G</button>
+            <button class="key" id="keyA">A</button>
+            <button class="key" id="keyB">B</button>
         </div>
     </div>
     <script src="script.js"></script>


### PR DESCRIPTION
Using button elements instead of divs for piano keys (more sensible semantics), made description shorter and clearer.