### PR TITLE
Added requirement to include built version to task 5-12

### DIFF
--- a/Lecture05/Exercise/templateExercise5/readme.md
+++ b/Lecture05/Exercise/templateExercise5/readme.md
@@ -27,7 +27,11 @@ Successfully completing this exercise will earn **5 points**.
 ---
 
 ## **Submission Requirements**
-- Submit the TypeScript project as a **ZIP file via Moodle** or provide a GitHub repository link.
+- Submit the TypeScript project as a **`.zip` file via Moodle**
+- your submission **must include a built version of the app**:
+   - your app **must run without installing or running TypeScript / tsc**
+   - build your `.ts` source files using the `tsc` command and include the built `.js` files to the submission
+   - serving the files via a webserver (e.g. VSCode webserver plugin) must be sufficient to run your app
 - The submission must include:
   1. **Project Setup**: Properly configured TypeScript environment.
   2. **Typed Variables**: Type annotations applied where necessary.

--- a/Lecture06/Exercise/templateExercise6/readme.md
+++ b/Lecture06/Exercise/templateExercise6/readme.md
@@ -33,6 +33,12 @@ Once each module is completed, the team will work together to **integrate** thei
 
 ---
 
+## Submission requirements
+- your submission **must include a built version of the app**:
+   - your app **must run without installing or running TypeScript / tsc**
+   - build your `.ts` source files using the `tsc` command and include the built `.js` files to the submission
+   - serving the files via a webserver (e.g. VSCode webserver plugin) must be sufficient to run your app
+
 ## **Evaluation Criteria**
 - **Module Completion:** Each task is fullfiled correctly? (8 points)
 - **Final Integration:** Is the application fully functional and well-integrated? (2 points)

--- a/Lecture07/Exercise/templateExercise7/readme.md
+++ b/Lecture07/Exercise/templateExercise7/readme.md
@@ -35,7 +35,11 @@ You can earn **up to 10 points** based on the successful completion of specific 
 ---
 
 ## **Submission Requirements**
-- **Submit the project as a ZIP file via Moodle.**
+- **Submit the project as a `.zip` file via Moodle.**
+- your submission **must include a built version of the app**:
+   - your app **must run without installing or running TypeScript / tsc**
+   - build your `.ts` source files using the `tsc` command and include the built `.js` files to the submission
+   - serving the files via a webserver (e.g. VSCode webserver plugin) must be sufficient to run your app
 - **Ensure full documentation** with comments explaining key components.
 - **Maintain type safety** using TypeScript best practices.
 

--- a/Lecture08/Exercise/Readme.md
+++ b/Lecture08/Exercise/Readme.md
@@ -337,6 +337,12 @@ main();
 
 ---
 
+## Submission requirements
+- your submission **must include a built version of the app**:
+   - your app **must run without installing or running TypeScript / tsc**
+   - build your `.ts` source files using the `tsc` command and include the built `.js` files to the submission
+   - serving the files via a webserver (e.g. VSCode webserver plugin) must be sufficient to run your app
+
 ## 🎯 **What to Deliver**
 
 1. **Working registration and login** with `ApiService` (or `StateManager`).

--- a/Lecture09/Exercise/Readme.md
+++ b/Lecture09/Exercise/Readme.md
@@ -186,6 +186,10 @@ export interface User {
 
 ## 📢 Submission & Testing Notes
 
+- your submission **must include a built version of the app**:
+   - your app **must run without installing or running TypeScript / tsc**
+   - build your `.ts` source files using the `tsc` command and include the built `.js` files to the submission
+   - serving the files via a webserver (e.g. VSCode webserver plugin) must be sufficient to run your app
 - Test with multiple accounts: register 2–3 test users  
 - Send messages back and forth to see how conversations work  
 - If a message doesn’t appear, check browser console or inspect the JSON payload  

--- a/Lecture10/Exercise/Readme.md
+++ b/Lecture10/Exercise/Readme.md
@@ -112,6 +112,12 @@ Example:
 
 ## **Submission Requirements**
 
+**General requirements**:
+   * your submission **must include a built version of the app**, which means your app **must run without installing or running Angular**
+   * run `ng build --base-href .` to build your app, afterwards you can use your app via any webserver (e.g. VSCode internal webserver) by navigating to the path containing the built version: `messenger-frontend/dist/messenger-frontend/browser/`
+   * put your whole project folder (including the built version) into a `.zip` archive, but **don't include the `node_modules` folder**!
+
+**Implementation requirements**: 
 1. A working Angular project named `messenger-frontend`.
 2. Feature modules `auth` and `message` correctly implemented.
 3. Routing between Intro, Login, and Message List pages functional.

--- a/Lecture11/Exercise/Readme.md
+++ b/Lecture11/Exercise/Readme.md
@@ -49,16 +49,16 @@ Total: **7 Points**
   </div>
   ```
 
-### **2. User Login Using Mock AuthService**
+### **2. User Login Using Mock ApiService**
 
-* Use provided `AuthService` mock to perform login:
+* Use provided `ApiService` mock (see `src/app/api.service.ts`) to perform login:
 
 #### Implementation:
 
-* Inject `AuthService` and call:
+* Inject `ApiService` and call:
 
   ```ts
-  auth.login(username, password);
+  api.login(username, password);
   ```
 * Store login state via a signal or localStorage.
 * Implement a **route guard** to redirect to login if not authenticated.
@@ -148,7 +148,7 @@ sendMessage(): void {
 
 | Task                                                   | Max Points |
 | ------------------------------------------------------ | ---------- |
-| Login with Mock AuthService                            | 1          |
+| Login with Mock ApiService                            | 1          |
 | Contact List & Conversations  + Send Message via API   | 4          |
 | Refresh + Auto Scroll + Routing Guard for Auth         | 2          |
 | Fetch & Signals for Loading Messages                   | 3          |
@@ -158,10 +158,17 @@ sendMessage(): void {
 
 ## **Submission Requirements**
 
+**General requirements**:
+   * your submission **must include a built version of the app**, which means your app **must run without installing or running Angular**
+   * run `ng build --base-href .` to build your app, afterwards you can use your app via any webserver (e.g. VSCode internal webserver) by navigating to the path containing the built version: `messenger-frontend/dist/messenger-frontend/browser/`
+   * put your whole project folder (including the built version) into a `.zip` archive, but **don't include the `node_modules` folder**!
+
+**Implementation requirements**: 
+
 * Continue in your Week 10 `messenger-frontend` project.
 * Replace observable logic with **signals**.
 * Use **native fetch API** for backend communication.
-* Auth logic must follow the provided mock `AuthService` example.
+* Auth logic must follow the provided mock `ApiService` example.
 * Contact selection triggers conversation updates.
 * Sending messages uses API + immediately appends locally.
 * App includes refresh button and scroll-to-latest behavior.

--- a/Lecture12/Exercise/templateExercise12/Readme.md
+++ b/Lecture12/Exercise/templateExercise12/Readme.md
@@ -100,6 +100,11 @@ Add a component `notification-bubble`, which informs the user about **new incomi
 * the bubble shows **name** and **message content** of the new message
 * a **click on the bubble opens the conversation** with this person and closes the bubble
 
+## General requirements
+   * your submission **must include a built version of the app**, which means your app **must run without installing or running Angular**
+   * run `ng build --base-href .` to build your app, afterwards you can use your app via any webserver (e.g. VSCode internal webserver) by navigating to the path containing the built version: `messenger-frontend/dist/messenger-frontend/browser/`
+   * put your whole project folder (including the built version) into a `.zip` archive, but **don't include the `node_modules` folder**!
+
 ## Hints
 Some hints for implementing the tasks:
 * **Services**: create new services `WebSocketService` and `LocalStorageService` for encapsulating the logic interacting with LocalStorage and the WebSocket.


### PR DESCRIPTION
For being able to quickly check submissions, it's crucial that the students submit built versions of their submissions, so that they can run directly using a webserver like xampp or VSCode internal webserver. So for `.ts` files the transpiled `.js` files must be included and for angular a built version of the app.

Therefore I've added this requirement to all tasks from 5-12.

For task 11 I've fixed the reference to `ApiService` which is included in the example submission, while `AuthService` is not.